### PR TITLE
`updateCoupon` documentation error

### DIFF
--- a/docs/Body10.md
+++ b/docs/Body10.md
@@ -3,11 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**value** | **String** | The actual coupon code. | [optional] 
-**usageLimit** | **Number** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  | [optional] 
-**startDate** | **Date** | Timestamp at which point the coupon becomes valid. | [optional] 
-**expiryDate** | **Date** | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. | [optional] 
-**recipientIntegrationId** | **String** | The integration ID for this coupon&#39;s beneficiary&#39;s profile | [optional] 
-**attributes** | **Object** | Arbitrary properties associated with this item | [optional] 
+**usageLimit** | **Number** | The number of times a coupon code can be redeemed. This can be set to 0 for no limit, but any campaign usage limits will still apply.  | [optional]
+**startDate** | **Date** | Timestamp at which point the coupon becomes valid. | [optional]
+**expiryDate** | **Date** | Expiry date of the coupon. Coupon never expires if this is omitted, zero, or negative. | [optional]
+**recipientIntegrationId** | **String** | The integration ID for this coupon&#39;s beneficiary&#39;s profile | [optional]
+**attributes** | **Object** | Arbitrary properties associated with this item | [optional]
 
 


### PR DESCRIPTION
The documentation for the JavaScript Management API differs to the API Reference on Talon.One's developers page.

The [API docs ](https://github.com/talon-one/talon_one.js/blob/39ce116d7523cc418a8acb4d416e745d3f9590e7/docs/Body10.md)state that you can pass in a `value` property in the body of the request to update a coupon's code. 

When this property is included, the following error is returned by Talon.One's API:
`The submitted data was invalid. ... additional_property_not_allowed ...`

The [API Reference on the developers page](http://developers.talon.one/Management-API/API-Reference#updateCoupon), doesn't have the `value` property listed as a Body Parameter.

This PR contains appropriate changes to the `updateCoupon` documentation.