### PR TITLE
chore: Cleanup README & improve package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,36 +165,16 @@ const customerSession = TalonOne.NewCustomerSessionV2.constructFromObject({
   ]
 });
 
-// ----------------------------------------------------------------- //
-// Example 1: pass `responseContent` to control response information //
-// ----------------------------------------------------------------- //
-
 //Initializing an integration request wrapping the customer session
 const integrationRequest = new TalonOne.IntegrationRequest(customerSession);
 
-// Optional response contents to attach to the response (Look at ResponseContentEnum for full list of options) 
-integrationRequest.responseContent = ['customerSession', 'customerProfile']
+// Optional list of requested information to be present on the response.
+// See src/model/IntegrationRequest#ResponseContentEnum for full list of supported values
+// integrationRequest.responseContent = [
+//   IntegrationRequest.ResponseContentEnum.customerSession,
+//   IntegrationRequest.ResponseContentEnum.customerProfile
+// ]
 
-integrationApi
-  .updateCustomerSessionV2("example_integration_v2_id", integrationRequest)
-  .then(
-    function(data) {
-      console.log(JSON.stringify(data, null, 2));
-    },
-    function(error) {
-      console.error(error);
-    }
-  );
-
-
-// ------------------------------------------------------------------ //
-// Example 2: leave `responseContent` empty for bare minimum response //
-// ------------------------------------------------------------------ //
-
-// Initializing an integration request wrapping the customer session
-const integrationRequest2 = new TalonOne.IntegrationRequest(customerSession);
-
-// Leaving `responseContent` unassigned will response with the bare minimum information from api (effects, created coupons and created referrals)
 integrationApi
   .updateCustomerSessionV2("example_integration_v2_id", integrationRequest)
   .then(

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ const integrationRequest = new TalonOne.IntegrationRequest(customerSession);
 // Optional list of requested information to be present on the response.
 // See src/model/IntegrationRequest#ResponseContentEnum for full list of supported values
 // integrationRequest.responseContent = [
-//   IntegrationRequest.ResponseContentEnum.customerSession,
-//   IntegrationRequest.ResponseContentEnum.customerProfile
+//   TalonOne.IntegrationRequest.ResponseContentEnum.customerSession,
+//   TalonOne.IntegrationRequest.ResponseContentEnum.customerProfile
 // ]
 
 integrationApi

--- a/package.json
+++ b/package.json
@@ -2,6 +2,21 @@
   "name": "talon_one",
   "version": "4.0.0",
   "description": "Talon.One API SDK for Javascript",
+  "homepage": "https://developers.talon.one/SDKs/JavaScript",
+  "author": {
+    "name": "Talon.One Developers",
+    "url": "https://developers.talon.one"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/talon-one/talon_one.js.git"
+  },
+  "bugs": {
+    "url" : "https://github.com/talon-one/talon_one.js/issues"
+  },
+  "engines": {
+    "node": ">=4"
+  },
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
@@ -12,10 +27,10 @@
     "fs": false
   },
   "dependencies": {
-    "@babel/cli": "^7.0.0",
     "superagent": "3.7.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/talon-one/talon_one.js.git"
   },
   "bugs": {
-    "url" : "https://github.com/talon-one/talon_one.js/issues"
+    "url": "https://github.com/talon-one/talon_one.js/issues"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
 - `README.md`
   - Simplify APIv2 code sample
   - Correct usage of `ResponseContentEnum`

 - Make `package.json` more official
   - Add missing configs for: homepage, author, repository, bugs & engines
   - Require `@babel/cli` as a dev-dependency, it's not needed in production (helps supporting node.js versions all the way back to `>=4`)
