### PR TITLE
Added "opts" to update profile fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "url": "https://github.com/talon-one/talon_one.js.git"
   },
   "bugs": {
-    "url": "https://github.com/talon-one/talon_one.js/issues"
+    "url": "https://github.com/talon-one/talon_one.js/issues",
+    "postinstall": "npm run build",
   },
   "engines": {
     "node": ">=4"
   },
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "prepack": "babel src -d dist",
     "test": "mocha --require @babel/register --recursive"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "url": "https://github.com/talon-one/talon_one.js.git"
   },
   "bugs": {
-    "url": "https://github.com/talon-one/talon_one.js/issues",
-    "postinstall": "npm run build"
+    "url": "https://github.com/talon-one/talon_one.js/issues"
   },
   "engines": {
     "node": ">=4"
@@ -22,7 +21,8 @@
   "main": "dist/index.js",
   "scripts": {
     "prepack": "babel src -d dist",
-    "test": "mocha --require @babel/register --recursive"
+    "test": "mocha --require @babel/register --recursive",
+    "postinstall": "babel src -d dist"
   },
   "browser": {
     "fs": false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "bugs": {
     "url": "https://github.com/talon-one/talon_one.js/issues",
-    "postinstall": "npm run build",
+    "postinstall": "npm run build"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=4"
   },
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "scripts": {
     "prepack": "babel src -d dist",
     "test": "mocha --require @babel/register --recursive"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prepack": "babel src -d dist",
     "test": "mocha --require @babel/register --recursive",
-    "postinstall": "babel src -d dist"
+    "postinstall": "npm run prepack"
   },
   "browser": {
     "fs": false

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prepack": "babel src -d dist",
-    "test": "mocha --require @babel/register --recursive",
-    "postinstall": "npm run prepack"
+    "test": "mocha --require @babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/src/api/IntegrationApi.js
+++ b/src/api/IntegrationApi.js
@@ -478,7 +478,7 @@ export default class IntegrationApi {
      * @param {module:model/NewCustomerProfile} body 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/CustomerProfileUpdate} and HTTP response
      */
-    updateCustomerProfileV2WithHttpInfo(customerProfileId, body) {
+    updateCustomerProfileV2WithHttpInfo(customerProfileId, body, opts) {
       let postBody = body;
       // verify the required parameter 'customerProfileId' is set
       if (customerProfileId === undefined || customerProfileId === null) {
@@ -493,6 +493,7 @@ export default class IntegrationApi {
         'customerProfileId': customerProfileId
       };
       let queryParams = {
+        ...opts
       };
       let headerParams = {
       };
@@ -517,10 +518,10 @@ export default class IntegrationApi {
      * @param {module:model/NewCustomerProfile} body 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/CustomerProfileUpdate}
      */
-    updateCustomerProfileV2(customerProfileId, body) {
-      return this.updateCustomerProfileV2WithHttpInfo(customerProfileId, body)
+    updateCustomerProfileV2(customerProfileId, body, opts) {
+      return this.updateCustomerProfileV2WithHttpInfo(customerProfileId, body, opts)
         .then(function(response_and_data) {
-          return response_and_data.data;
+          return response_and_data.response.body; // response_and_data.data is empty
         });
     }
 


### PR DESCRIPTION
As far as I understand this PR will be rejected as the code is generated by a tool, I created it just to show what is missing.

Added:
1. Posibility to pass "opts" to updateCustomerProfileV2WithHttpInfo and updateCustomerProfileV2.
2. Updated return value from `response_and_data.data` to `response_and_data.response.body`.

Why:
1. Now it's possible to pass `runRuleEngine=true` to the update user profiles requests.
2. `response_and_data.data` is empty